### PR TITLE
fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.5-alpine3.7
 
-RUN apk --update add make g++ cmake && rm -rf /var/cache/apk/*
+RUN apk --update add make g++ cmake libgit2-dev && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 COPY Gemfile /app/Gemfile


### PR DESCRIPTION
### 概要

pronto gem が依存している rugged gem が依存しているネイティブライブラリ `libgit2` のソースファイルが、 `libgit2-dev` を add しないと落ちてこないため docker build ができなくなっていました。
なので、 `libgit2-dev` も add するようにします。
